### PR TITLE
add an active caching model

### DIFF
--- a/src/app/cache.rs
+++ b/src/app/cache.rs
@@ -2,7 +2,7 @@ use dashmap::DashMap;
 use std::{sync::Arc, time::Instant};
 use tracing::trace;
 
-const EXPIRY_INTERVAL: u64 = 600;
+const EXPIRY_INTERVAL: u64 = 7200;
 
 // Banned users are stored as None
 #[derive(Clone, Default)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23,28 +23,34 @@ impl App {
         &self,
         ids: Vec<String>,
         names: Vec<String>,
+        ignore_cache: Option<bool>,
     ) -> Result<HashMap<String, String>> {
         let mut users = HashMap::new();
         let mut ids_to_request = Vec::new();
         let mut names_to_request = Vec::new();
 
-        for id in ids {
-            match self.users.get_login(&id) {
-                Some(Some(login)) => {
-                    users.insert(id, login);
+        if ignore_cache.unwrap_or(false) {
+            ids_to_request = ids.clone();
+            names_to_request = names.clone()
+        } else {
+            for id in ids {
+                match self.users.get_login(&id) {
+                    Some(Some(login)) => {
+                        users.insert(id, login);
+                    }
+                    Some(None) => (),
+                    None => ids_to_request.push(id),
                 }
-                Some(None) => (),
-                None => ids_to_request.push(id),
             }
-        }
 
-        for name in names {
-            match self.users.get_id(&name) {
-                Some(Some(id)) => {
-                    users.insert(id, name);
+            for name in names {
+                match self.users.get_id(&name) {
+                    Some(Some(id)) => {
+                        users.insert(id, name);
+                    }
+                    Some(None) => (),
+                    None => names_to_request.push(name),
                 }
-                Some(None) => (),
-                None => names_to_request.push(name),
             }
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23,13 +23,13 @@ impl App {
         &self,
         ids: Vec<String>,
         names: Vec<String>,
-        ignore_cache: Option<bool>,
+        ignore_cache: bool,
     ) -> Result<HashMap<String, String>> {
         let mut users = HashMap::new();
         let mut ids_to_request = Vec::new();
         let mut names_to_request = Vec::new();
 
-        if ignore_cache.unwrap_or(false) {
+        if ignore_cache {
             ids_to_request = ids.clone();
             names_to_request = names.clone()
         } else {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -31,7 +31,7 @@ impl App {
 
         if ignore_cache {
             ids_to_request = ids.clone();
-            names_to_request = names.clone()
+            names_to_request = names.clone();
         } else {
             for id in ids {
                 match self.users.get_login(&id) {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -79,7 +79,10 @@ impl Bot {
             loop {
                 let channel_ids = app.config.channels.read().unwrap().clone();
 
-                let interval = match app.get_users(Vec::from_iter(channel_ids), vec![]).await {
+                let interval = match app
+                    .get_users(Vec::from_iter(channel_ids), vec![], Some(true))
+                    .await
+                {
                     Ok(users) => {
                         info!("Joining {} channels", users.len());
                         for channel_login in users.into_values() {
@@ -285,7 +288,11 @@ impl Bot {
 
         let channels = self
             .app
-            .get_users(vec![], channels.iter().map(ToString::to_string).collect())
+            .get_users(
+                vec![],
+                channels.iter().map(ToString::to_string).collect(),
+                None,
+            )
             .await?;
 
         {

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -80,7 +80,7 @@ impl Bot {
                 let channel_ids = app.config.channels.read().unwrap().clone();
 
                 let interval = match app
-                    .get_users(Vec::from_iter(channel_ids), vec![], Some(true))
+                    .get_users(Vec::from_iter(channel_ids), vec![], true)
                     .await
                 {
                     Ok(users) => {
@@ -291,7 +291,7 @@ impl Bot {
             .get_users(
                 vec![],
                 channels.iter().map(ToString::to_string).collect(),
-                None,
+                false,
             )
             .await?;
 

--- a/src/web/admin.rs
+++ b/src/web/admin.rs
@@ -72,7 +72,7 @@ pub async fn add_channels(
     app: State<App>,
     Json(ChannelsRequest { channels }): Json<ChannelsRequest>,
 ) -> Result<(), Error> {
-    let users = app.get_users(channels, vec![]).await?;
+    let users = app.get_users(channels, vec![], None).await?;
     let names = users.into_values().collect();
 
     bot_tx.send(BotMessage::JoinChannels(names)).await.unwrap();
@@ -85,7 +85,7 @@ pub async fn remove_channels(
     app: State<App>,
     Json(ChannelsRequest { channels }): Json<ChannelsRequest>,
 ) -> Result<(), Error> {
-    let users = app.get_users(channels, vec![]).await?;
+    let users = app.get_users(channels, vec![], None).await?;
     let names = users.into_values().collect();
 
     bot_tx.send(BotMessage::PartChannels(names)).await.unwrap();

--- a/src/web/admin.rs
+++ b/src/web/admin.rs
@@ -72,7 +72,7 @@ pub async fn add_channels(
     app: State<App>,
     Json(ChannelsRequest { channels }): Json<ChannelsRequest>,
 ) -> Result<(), Error> {
-    let users = app.get_users(channels, vec![], None).await?;
+    let users = app.get_users(channels, vec![], false).await?;
     let names = users.into_values().collect();
 
     bot_tx.send(BotMessage::JoinChannels(names)).await.unwrap();
@@ -85,7 +85,7 @@ pub async fn remove_channels(
     app: State<App>,
     Json(ChannelsRequest { channels }): Json<ChannelsRequest>,
 ) -> Result<(), Error> {
-    let users = app.get_users(channels, vec![], None).await?;
+    let users = app.get_users(channels, vec![], false).await?;
     let names = users.into_values().collect();
 
     bot_tx.send(BotMessage::PartChannels(names)).await.unwrap();

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -33,7 +33,7 @@ pub async fn get_channels(app: State<App>) -> impl IntoApiResponse {
     let channel_ids = app.config.channels.read().unwrap().clone();
 
     let channels = app
-        .get_users(Vec::from_iter(channel_ids), vec![], None)
+        .get_users(Vec::from_iter(channel_ids), vec![], false)
         .await
         .unwrap();
 

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -33,7 +33,7 @@ pub async fn get_channels(app: State<App>) -> impl IntoApiResponse {
     let channel_ids = app.config.channels.read().unwrap().clone();
 
     let channels = app
-        .get_users(Vec::from_iter(channel_ids), vec![])
+        .get_users(Vec::from_iter(channel_ids), vec![], None)
         .await
         .unwrap();
 


### PR DESCRIPTION
this PR aims to improve slow load times when querying the `/channels` endpoint, this is especially noticeable on instances with lots of channels

the cache's `EXPIRY_INTERVAL` is now set to `7200` (2 hours), but will get updated every hour when called on the channel rejoin interval with the `ignore_cache = true` flag

this saves unnecessary requests when querying the `/channels` endpoint, and speeds up page load times with the channels always being ready in cache