### PR TITLE
Impr/add name change route

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,7 +1,6 @@
 mod migrations;
 pub mod schema;
 pub mod writer;
-
 use std::collections::HashSet;
 
 pub use migrations::run as setup_db;
@@ -387,27 +386,21 @@ pub async fn get_user_name_history(
     db: &Client,
     user_id: &str,
 ) -> Result<PreviousNames> {
-    #[derive(Deserialize, Row, Debug)]
+    #[derive(Deserialize, Row)]
     struct SingleNameHistory {
         pub user_login: String,
-        pub last_timestamp: String,
-        pub first_timestamp: String,
+        pub last_timestamp: i32,
+        pub first_timestamp: i32,
     }
 
-    let query = "SELECT user_login, MAX(timestamp) AS last_timestamp FROM rustlog.message_structured WHERE user_id = ? GROUP BY user_login".to_owned();
+    let query = "SELECT user_login, toDateTime((MAX(timestamp))) AS last_timestamp, toDateTime(MIN(timestamp)) AS first_timestamp FROM message_structured WHERE user_id = ? GROUP BY user_login".to_owned();
 
     let query = db.query(&query).bind(user_id);
 
     let name_history_rows = query.fetch_all::<SingleNameHistory>().await?;
 
-    // Log to console the name history rows
-    for name_history_row in &name_history_rows {
-        println!("Name history row: {:?}", name_history_row);
-    }
-
     let mut seen_logins = HashSet::new();
     
-    // If name starts with ':' (NOTICE, CLEARCHAT? Parse error?), remove char and deduplicate rows
     let names = name_history_rows
         .into_iter()
         .filter_map(|name_history_row: SingleNameHistory| {
@@ -420,8 +413,12 @@ pub async fn get_user_name_history(
             if seen_logins.insert(sanitized_user_login.clone()) {
                 Some(PreviousName {
                     user_login: sanitized_user_login,
-                    last_timestamp: name_history_row.last_timestamp,
-                    first_timestamp: name_history_row.first_timestamp,
+                    last_timestamp: DateTime::from_timestamp(name_history_row.last_timestamp.into(), 0)
+                        .expect("Invalid DateTime")
+                        .to_rfc3339(),
+                    first_timestamp: DateTime::from_timestamp(name_history_row.first_timestamp.into(), 0)
+                        .expect("Invalid DateTime")
+                        .to_rfc3339(),
                 })
             } else {
                 None

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -3,7 +3,7 @@ use super::{
     schema::{
         AvailableLogs, AvailableLogsParams, Channel, ChannelIdType, ChannelLogsByDatePath,
         ChannelLogsStats, ChannelParam, ChannelsList, LogsParams, LogsPathChannel, SearchParams,
-        UserLogPathParams, UserLogsPath, UserLogsStats, UserParam,
+        UserLogPathParams, UserLogsPath, UserLogsStats, UserParam, UserNameHistoryParam
     },
 };
 use crate::{
@@ -503,6 +503,20 @@ async fn search_user_logs(
         response_type: logs_params.response_type(),
     };
     Ok(logs)
+}
+
+
+pub async fn get_user_name_history(
+    app: State<App>,
+    Path(UserNameHistoryParam {
+        user_id,
+    }): Path<UserNameHistoryParam>,
+) -> Result<impl IntoApiResponse> {
+    app.check_opted_out(&user_id, None)?;
+
+    let names = db::get_user_name_history(&app.db,&user_id).await?;
+
+    Ok(Json(names))
 }
 
 pub async fn optout(app: State<App>) -> Json<String> {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -167,6 +167,12 @@ pub async fn run(app: App, mut shutdown_rx: ShutdownRx, bot_tx: Sender<BotMessag
                 op.description("Get user stats")
             }),
         )
+        .api_route(
+            "/namehistory/:user_id",
+            get_with(handlers::get_user_name_history, |op| {
+                op.description("Get user name history by provided user id")
+            }),
+        )
         .api_route("/optout", post(handlers::optout))
         .api_route("/capabilities", get(capabilities))
         .route("/docs", Redoc::new("/openapi.json").axum_route())

--- a/src/web/schema.rs
+++ b/src/web/schema.rs
@@ -1,4 +1,5 @@
 use super::responders::logs::{JsonResponseType, LogsResponseType};
+use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::Display;
@@ -185,6 +186,8 @@ pub struct UserNameHistoryParam {
 #[derive(Serialize, JsonSchema)]
 pub struct PreviousName {
     pub user_login: String,
-    pub last_timestamp: String,
-    pub first_timestamp: String,
+    #[schemars(with = "String")]
+    pub last_timestamp: DateTime<Utc>,
+    #[schemars(with = "String")]
+    pub first_timestamp: DateTime<Utc>,
 }

--- a/src/web/schema.rs
+++ b/src/web/schema.rs
@@ -176,3 +176,17 @@ pub struct UserLogsStats {
     pub user_id: String,
     pub message_count: u64,
 }
+
+#[derive(Deserialize, JsonSchema)]
+pub struct UserNameHistoryParam {
+    pub user_id: String,
+}
+
+#[derive(Serialize, JsonSchema)]
+pub struct PreviousName {
+    pub user_login: String,
+    pub last_timestamp: String,
+    pub first_timestamp: String,
+}
+
+pub type PreviousNames = Vec<PreviousName>;

--- a/src/web/schema.rs
+++ b/src/web/schema.rs
@@ -188,5 +188,3 @@ pub struct PreviousName {
     pub last_timestamp: String,
     pub first_timestamp: String,
 }
-
-pub type PreviousNames = Vec<PreviousName>;


### PR DESCRIPTION
Adds a route to check for a user's previous name history, showing the first and last date seen for each username.

Should still respect user opt-outs.

The query itself consistently takes around ~100ms on my local instance, scanning 1.5 billion rows.

Very (completely) new to rust so I mainly just copied your existing implementations of stuff, and probably missed something.

Tested and worked fine locally. 