### PR TITLE
check if system-msg is empty

### DIFF
--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -258,7 +258,11 @@ impl<'a> StructuredMessage<'a> {
                 {
                     if !self.text.is_empty() {
                         let user_message = extract_message_text(&self.text);
-                        Cow::Owned(format!("{system_message} {user_message}"))
+                        if !system_message.is_empty() {
+                            Cow::Owned(format!("{system_message} {user_message}"))
+                        } else {
+                            Cow::Borrowed(user_message)
+                        }
                     } else {
                         Cow::Borrowed(system_message)
                     }


### PR DESCRIPTION
This PR handles empty `system-msg` tags

Before, in the case of chat `/announce`-ments (sent as `USERNOTICE`-s), this would result in a space character being appended before the message (`user_friendly_text`). Which is unexpected and breaks the frontend parser by offsetting it by one character ~

![image](https://github.com/user-attachments/assets/8364c01f-11fe-4c71-ae3d-0956d4b3fc5a)
![image](https://github.com/user-attachments/assets/44434442-b1f6-491e-be79-d0a365469b5f)